### PR TITLE
Update readme with new SafeInt scalar

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -63,6 +63,7 @@ generates:
         JSON: any
         Semver: string
         Bech32Address: string
+        SafeInt: number
 ```
 3. Add `codegen` command to `package.json`
 ```json

--- a/packages/core/codegen.yml
+++ b/packages/core/codegen.yml
@@ -10,3 +10,9 @@ generates:
     config:
       immutableTypes: true
       useTypeImports: true
+      scalars:
+        # Temporarily map to any, see DAT-16
+        JSON: any
+        Semver: string
+        Bech32Address: string
+        SafeInt: number


### PR DESCRIPTION
Use SafeInt for sequence on AccountId GraphQL schema because the old Int type would overflow the Int type