### PR TITLE
Don't allow aggregated aggregated queries

### DIFF
--- a/.changeset/gentle-carpets-double.md
+++ b/.changeset/gentle-carpets-double.md
@@ -1,0 +1,5 @@
+---
+"@abstract-money/cosmwasm-utils": patch
+---
+
+Disallow aggregated aggregated queries

--- a/packages/cosmwasm-utils/src/client/MultiqueryCosmWasmClient.ts
+++ b/packages/cosmwasm-utils/src/client/MultiqueryCosmWasmClient.ts
@@ -119,7 +119,10 @@ export class MultiqueryCosmWasmClient extends CosmWasmClient {
     return new Promise((resolve, reject) => {
       this.queryQueue.push({ address, queryMsg, resolve, reject })
 
-      if (this.queryQueue.length >= this.batchSizeLimit) {
+      if (
+        this.queryQueue.length >= this.batchSizeLimit ||
+        address === this.multiqueryContractAddress
+      ) {
         this.processQueryQueue()
       }
     })
@@ -149,6 +152,9 @@ export class MultiqueryCosmWasmClient extends CosmWasmClient {
       address,
       data: jsonToBinary(queryMsg),
     }))
+
+    console.log('calls length', calls.length)
+    console.log('calls', calls)
 
     const result = (await super.queryContractSmart(
       this.multiqueryContractAddress,


### PR DESCRIPTION
Title. When using the aggregated client, calls could be doubly aggregated.